### PR TITLE
Add SSH key fingerprints to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ To join, submit a pull request with your public key at `users/<you>/authorized_k
     $
     $ # After ~10 minutes, account is auto-created
     $ # Login!
+    $ # SHA256:UqnBpin2WJqzWNMisueYH6sVIft5GYkXVpa7WwP44m8
+    $ # MD5:dc:49:95:99:e4:cf:a9:87:ac:37:f4:f5:8b:bd:5e:89
     $ ssh -i ~/.ssh/id_rsa_rwrs <you>@rw.rs
     $
     $ # Set your motd

--- a/bin/get_ssh_fingerprints.sh
+++ b/bin/get_ssh_fingerprints.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+
+for PUBKEY in /etc/ssh/*.pub; do
+	ssh-keygen -l -f "$PUBKEY" | awk -v OFS='\t' '{ print $2, $4 }'
+	ssh-keygen -l -f "$PUBKEY" -E md5 | awk -v OFS='\t' '{ print $2, $4 }'
+done


### PR DESCRIPTION
Script actually produces SSH key fingerprints for `ecdsa`, `ed25519`, and `rsa` but I only copied the `rsa` fingerprints onto the README.