### PR TITLE
allow unicode in motd

### DIFF
--- a/bin/gen_motd.sh
+++ b/bin/gen_motd.sh
@@ -15,11 +15,12 @@ source "$(cd $(dirname "${BASH_SOURCE[0]}") &>/dev/null && pwd)/common.sh"
     find /home -maxdepth 2 -type f -name motd | sort | while read motd_path; do
         user=$(echo $motd_path | cut -d/ -f3)
         motd=$(
-            { timeout 1 cat $motd_path || true; } | \
-            sed -E \
+            timeout 1 sed -E \
                 -e 's/[^[:graph:][:space:]]//g' \
                 -e 's/[[:space:]]+/ /g' \
-                -e 's/^(.{0,24}).*$/\1/'
+                -e 's/^(.{0,24}).*$/\1/' \
+                $motd_path \
+            || true
         )
         printf "%${max_uname_len}s: %-24s\n" "$user" "$motd"
     done | column -xc 80

--- a/bin/gen_motd.sh
+++ b/bin/gen_motd.sh
@@ -14,7 +14,7 @@ source "$(cd $(dirname "${BASH_SOURCE[0]}") &>/dev/null && pwd)/common.sh"
     echo
     find /home -mindepth 2 -maxdepth 2 -type f -name motd | sort | while read motd_path; do
         user=$(echo $motd_path | cut -d/ -f3)
-        motd=$(
+        motd_padded=$(
             timeout 1 sed -E \
                 -e 's/[^[:graph:][:space:]]//g' \
                 -e 's/[[:space:]]+/ /g' \
@@ -23,7 +23,7 @@ source "$(cd $(dirname "${BASH_SOURCE[0]}") &>/dev/null && pwd)/common.sh"
                 $motd_path \
             || true
         )
-        printf "%${max_uname_len}s: %s\n" "$user" "$motd"
+        printf "%${max_uname_len}s: %s\n" "$user" "$motd_padded"
     done | column -xc 80
     echo
     echo "   $rwrs_url"

--- a/bin/gen_motd.sh
+++ b/bin/gen_motd.sh
@@ -18,7 +18,7 @@ source "$(cd $(dirname "${BASH_SOURCE[0]}") &>/dev/null && pwd)/common.sh"
             { timeout 1 cat $motd_path || true; } | \
             tr '[:space:]' " " | \
             sed -e 's/[[:space:]]\+/ /g' | \
-            tr -cd '[:graph:][:space:]' | \
+            sed -e 's/[^[:graph:][:space:]]//g' | \
             cut -c1-24 \
         )
         printf "%${max_uname_len}s: %-24s\n" "$user" "$motd"

--- a/bin/gen_motd.sh
+++ b/bin/gen_motd.sh
@@ -12,7 +12,7 @@ source "$(cd $(dirname "${BASH_SOURCE[0]}") &>/dev/null && pwd)/common.sh"
     echo "   MOTD generated $(date)"
     echo '   (Psst, write up to 24 bytes in a file called ~/motd)'
     echo
-    find /home -maxdepth 2 -type f -name motd | sort | while read motd_path; do
+    find /home -mindepth 2 -maxdepth 2 -type f -name motd | sort | while read motd_path; do
         user=$(echo $motd_path | cut -d/ -f3)
         motd=$(
             timeout 1 sed -E \

--- a/bin/gen_motd.sh
+++ b/bin/gen_motd.sh
@@ -16,7 +16,6 @@ source "$(cd $(dirname "${BASH_SOURCE[0]}") &>/dev/null && pwd)/common.sh"
         user=$(echo $motd_path | cut -d/ -f3)
         motd=$(
             { timeout 1 cat $motd_path || true; } | \
-            tr '[:space:]' " " | \
             sed -e 's/[[:space:]]\+/ /g' | \
             sed -e 's/[^[:graph:][:space:]]//g' | \
             cut -c1-24 \

--- a/bin/gen_motd.sh
+++ b/bin/gen_motd.sh
@@ -19,10 +19,11 @@ source "$(cd $(dirname "${BASH_SOURCE[0]}") &>/dev/null && pwd)/common.sh"
                 -e 's/[^[:graph:][:space:]]//g' \
                 -e 's/[[:space:]]+/ /g' \
                 -e 's/^(.{0,24}).*$/\1/' \
+                -e ':a; s/^.{0,23}$/& /; ta' \
                 $motd_path \
             || true
         )
-        printf "%${max_uname_len}s: %-24s\n" "$user" "$motd"
+        printf "%${max_uname_len}s: %s\n" "$user" "$motd"
     done | column -xc 80
     echo
     echo "   $rwrs_url"

--- a/bin/gen_motd.sh
+++ b/bin/gen_motd.sh
@@ -16,9 +16,10 @@ source "$(cd $(dirname "${BASH_SOURCE[0]}") &>/dev/null && pwd)/common.sh"
         user=$(echo $motd_path | cut -d/ -f3)
         motd=$(
             { timeout 1 cat $motd_path || true; } | \
-            sed -e 's/[^[:graph:][:space:]]//g' | \
-            sed -e 's/[[:space:]]\+/ /g' | \
-            cut -c1-24 \
+            sed -E \
+                -e 's/[^[:graph:][:space:]]//g' \
+                -e 's/[[:space:]]+/ /g' \
+                -e 's/^(.{0,24}).*$/\1/'
         )
         printf "%${max_uname_len}s: %-24s\n" "$user" "$motd"
     done | column -xc 80

--- a/bin/gen_motd.sh
+++ b/bin/gen_motd.sh
@@ -16,8 +16,8 @@ source "$(cd $(dirname "${BASH_SOURCE[0]}") &>/dev/null && pwd)/common.sh"
         user=$(echo $motd_path | cut -d/ -f3)
         motd=$(
             { timeout 1 cat $motd_path || true; } | \
-            sed -e 's/[[:space:]]\+/ /g' | \
             sed -e 's/[^[:graph:][:space:]]//g' | \
+            sed -e 's/[[:space:]]\+/ /g' | \
             cut -c1-24 \
         )
         printf "%${max_uname_len}s: %-24s\n" "$user" "$motd"


### PR DESCRIPTION
close https://github.com/adsr/rw.rs/issues/214

GNU `tr` seems to not support multibyte chars by design,
so replace it with GNU `sed`

---

The `cut -c1-24`
became `sed -E ... -e 's/^(.{0,24}).*$/\1/'`
but it may probably be ditched altogether 
as `printf ... %-24s` does its job. Ditch?

---

If you don't like `sed`, closest alternatives may be GNU `awk` or `perl`

---

also, minor addition: `find -mindepth 2`, as `motd` are not supposed to reside at `/home/motd`